### PR TITLE
fix: Add categories to ViewBag in Edit method for improved event crea…

### DIFF
--- a/Controllers/OrgEventsController.cs
+++ b/Controllers/OrgEventsController.cs
@@ -357,7 +357,7 @@ namespace EventTicketingSystem.Controllers
                     if (capObj == null)
                     {
                         ModelState.AddModelError("VenueId", "Selected venue does not exist.");
-                        tx.Rollback(); ViewBag.Venues = GetVenues(); return View(vm);
+                        tx.Rollback(); ViewBag.Venues = GetVenues(); ViewBag.Categories = GetCategories(); return View(vm);
                     }
                     capacity = Convert.ToInt32(capObj);
                 }
@@ -365,7 +365,7 @@ namespace EventTicketingSystem.Controllers
                 if (vm.TotalTickets > capacity)
                 {
                     ModelState.AddModelError("TotalTickets", $"Total tickets cannot exceed venue capacity ({capacity}).");
-                    tx.Rollback(); ViewBag.Venues = GetVenues(); return View(vm);
+                    tx.Rollback(); ViewBag.Venues = GetVenues(); ViewBag.Categories = GetCategories(); return View(vm);
                 }
 
                 // // 2) Insert the event (sold_count defaults to 0; status defaults to 'Upcoming')


### PR DESCRIPTION
This pull request makes a minor fix to the `Create` action in `OrgEventsController.cs` to ensure that the categories list is always available to the view when returning due to a validation error. This prevents issues where the categories dropdown might not be populated if the form is redisplayed after an error.

- Validation error handling:
  * Updated the error handling logic in `CreateEventVm` creation to set `ViewBag.Categories` alongside `ViewBag.Venues` when returning the view after a venue or ticket validation error.…tion validation