### PR TITLE
fix: Update date parameters in AdminReportsController 

### DIFF
--- a/Controllers/AdminReportsController.cs
+++ b/Controllers/AdminReportsController.cs
@@ -71,8 +71,11 @@ namespace EventTicketingSystem.Controllers
                 GROUP BY e.organizer_id, u.full_name
                 ORDER BY revenue DESC, tickets DESC;", conn))
             {
-                cmd.Parameters.AddWithValue("from", new DateTimeOffset(fromLocal, TimeSpan.Zero));
-                cmd.Parameters.AddWithValue("to", new DateTimeOffset(toLocalExclusive, TimeSpan.Zero));
+                var fromUtc = new DateTimeOffset(fromLocal, TimeZoneInfo.Local.GetUtcOffset(fromLocal)).ToUniversalTime();
+                var toUtc = new DateTimeOffset(toLocalExclusive, TimeZoneInfo.Local.GetUtcOffset(toLocalExclusive)).ToUniversalTime();
+
+                cmd.Parameters.AddWithValue("from", fromUtc);
+                cmd.Parameters.AddWithValue("to", toUtc);
 
                 using var r = cmd.ExecuteReader();
                 while (r.Read())
@@ -105,8 +108,11 @@ namespace EventTicketingSystem.Controllers
                 GROUP BY e.event_id, e.title, u.full_name, e.status, e.ticket_price, e.starts_at
                 ORDER BY revenue DESC, tickets DESC, e.starts_at DESC;", conn))
             {
-                cmd.Parameters.AddWithValue("from", new DateTimeOffset(fromLocal, TimeSpan.Zero));
-                cmd.Parameters.AddWithValue("to", new DateTimeOffset(toLocalExclusive, TimeSpan.Zero));
+                var fromUtc = new DateTimeOffset(fromLocal, TimeZoneInfo.Local.GetUtcOffset(fromLocal)).ToUniversalTime();
+                var toUtc = new DateTimeOffset(toLocalExclusive, TimeZoneInfo.Local.GetUtcOffset(toLocalExclusive)).ToUniversalTime();
+
+                cmd.Parameters.AddWithValue("from", fromUtc);
+                cmd.Parameters.AddWithValue("to", toUtc);
 
                 using var r = cmd.ExecuteReader();
                 while (r.Read())
@@ -153,8 +159,11 @@ namespace EventTicketingSystem.Controllers
                 GROUP BY e.event_id, e.title, u.full_name, e.status, e.ticket_price, e.starts_at
                 ORDER BY revenue DESC, tickets DESC, e.starts_at DESC;", conn);
 
-            cmd.Parameters.AddWithValue("from", new DateTimeOffset(fromLocal, TimeSpan.Zero));
-            cmd.Parameters.AddWithValue("to", new DateTimeOffset(toLocalExclusive, TimeSpan.Zero));
+            var fromUtc = new DateTimeOffset(fromLocal, TimeZoneInfo.Local.GetUtcOffset(fromLocal)).ToUniversalTime();
+            var toUtc = new DateTimeOffset(toLocalExclusive, TimeZoneInfo.Local.GetUtcOffset(toLocalExclusive)).ToUniversalTime();
+
+            cmd.Parameters.AddWithValue("from", fromUtc);
+            cmd.Parameters.AddWithValue("to", toUtc);
 
             using var r = cmd.ExecuteReader();
             while (r.Read())


### PR DESCRIPTION
This pull request updates how date parameters are handled in SQL queries within the `AdminReportsController`. The main change is to ensure that the `from` and `to` date parameters are always converted to UTC before being passed to the database, which helps prevent issues with time zone offsets and ensures consistent reporting.

**Date handling improvements:**

* All instances where `fromLocal` and `toLocalExclusive` are used as SQL parameters have been updated to convert these dates to UTC, using `TimeZoneInfo.Local.GetUtcOffset` and `.ToUniversalTime()`, before adding them to the SQL command. (`Controllers/AdminReportsController.cs` [[1]](diffhunk://#diff-a9ac2877fde479afb0a97391c357f0a6259992f4b8123463e8cf98aaf4b8e5c0L74-R78) [[2]](diffhunk://#diff-a9ac2877fde479afb0a97391c357f0a6259992f4b8123463e8cf98aaf4b8e5c0L108-R115) [[3]](diffhunk://#diff-a9ac2877fde479afb0a97391c357f0a6259992f4b8123463e8cf98aaf4b8e5c0L156-R166)…accurate time handling