### PR TITLE
feat: Implement event deletion functionality with confirmation view

### DIFF
--- a/Views/AdminEvents/Delete.cshtml
+++ b/Views/AdminEvents/Delete.cshtml
@@ -1,0 +1,36 @@
+@model EventTicketingSystem.Models.AdminEventRow
+@{
+    ViewData["Title"] = "Delete Event";
+    var bookingCount = (int)(ViewBag.BookingCount ?? 0);
+    var ticketCount = (int)(ViewBag.TicketCount ?? 0);
+}
+
+<div class="container py-4" style="max-width:720px;">
+    <h1 class="h4 mb-3">Delete Event</h1>
+
+    <div class="mb-3">
+        <div class="fw-semibold">@Model.Title</div>
+        <div class="text-muted small">Status: @Model.Status</div>
+        <div class="text-muted small">Bookings attached: @bookingCount</div>
+        <div class="text-muted small">Tickets attached: @ticketCount</div>
+    </div>
+
+    @if (Model.Status is "Cancelled" or "Completed")
+    {
+        <div class="alert alert-danger">
+            This will permanently delete the event and any related bookings and tickets. This action cannot be undone.
+        </div>
+        <form method="post">
+            @Html.AntiForgeryToken()
+            <a class="btn btn-outline-secondary" asp-action="Index">Cancel</a>
+            <button class="btn btn-danger" type="submit">Delete Event</button>
+        </form>
+    }
+    else
+    {
+        <div class="alert alert-warning">
+            Only <strong>Cancelled</strong> or <strong>Completed</strong> events can be deleted. Change the status first.
+        </div>
+        <a class="btn btn-outline-secondary" asp-action="Index">Back</a>
+    }
+</div>

--- a/Views/AdminEvents/Index.cshtml
+++ b/Views/AdminEvents/Index.cshtml
@@ -89,7 +89,11 @@
                                     <div class="btn-group gap-2">
                                         <a class="btn btn-sm btn-outline-secondary" asp-action="Edit"
                                             asp-route-id="@e.Id">Edit</a>
-
+                                        @if (e.Status == "Cancelled" || e.Status == "Completed")
+                                        {
+                                            <a class="btn btn-sm btn-outline-danger" asp-action="Delete"
+                                                asp-route-id="@e.Id">Delete</a>
+                                        }
                                         @* Status controls *@
                                         @if (e.Status == "Upcoming")
                                         {


### PR DESCRIPTION
This pull request adds support for deleting events from the admin interface, but restricts deletion to events that are either "Cancelled" or "Completed". It introduces both backend logic and frontend UI for safely deleting an event along with its associated bookings, tickets, and uploaded images.

**Event Deletion Feature:**

* Added `Delete` (GET and POST) actions to `AdminEventsController`, allowing admins to view a confirmation page and permanently delete an event and all related bookings and tickets, but only if the event status is "Cancelled" or "Completed". Associated image files are also removed from disk after deletion.

**User Interface Updates:**

* Created a new view `Views/AdminEvents/Delete.cshtml` that displays event details, booking/ticket counts, and a warning/confirmation for deletion. The delete button is only shown for eligible events.
* Updated `Views/AdminEvents/Index.cshtml` to show a "Delete" button next to events in the list only when their status is "Cancelled" or "Completed".