### PR TITLE
feat: Implement profile management with view and update functionality

### DIFF
--- a/Controllers/ProfileController.cs
+++ b/Controllers/ProfileController.cs
@@ -1,0 +1,148 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Mvc;
+using Npgsql;
+using EventTicketingSystem.Data;
+using EventTicketingSystem.Models;
+using EventTicketingSystem.Security; // for PasswordHasher
+
+namespace EventTicketingSystem.Controllers
+{
+    [Authorize] // any signed-in user
+    public class ProfileController : Controller
+    {
+        private readonly DbHelper _db;
+        public ProfileController(DbHelper db) { _db = db; }
+
+        // GET: /Profile
+        [HttpGet]
+        public IActionResult Index()
+        {
+            var userId = Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
+
+            using var conn = _db.GetConnection();
+            conn.Open();
+
+            using var cmd = new NpgsqlCommand(
+                "SELECT email, full_name FROM users WHERE user_id=@id LIMIT 1;", conn);
+            cmd.Parameters.AddWithValue("id", userId);
+
+            using var r = cmd.ExecuteReader();
+            if (!r.Read()) return NotFound();
+
+            var vm = new ProfileVm
+            {
+                Email = r.GetString(0),
+                FullName = r.GetString(1)
+            };
+            return View(vm);
+        }
+
+        // POST: /Profile
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Index(ProfileVm vm)
+        {
+            if (!ModelState.IsValid)
+                return View(vm);
+
+            var userId = Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
+
+            using var conn = _db.GetConnection();
+            conn.Open();
+            using var tx = conn.BeginTransaction();
+
+            try
+            {
+                // 1) Update name (always)
+                using (var upName = new NpgsqlCommand(
+                    "UPDATE users SET full_name=@n WHERE user_id=@id;", conn, tx))
+                {
+                    upName.Parameters.AddWithValue("n", vm.FullName);
+                    upName.Parameters.AddWithValue("id", userId);
+                    upName.ExecuteNonQuery();
+                }
+
+                // 2) If new password provided → verify current, then set new hash/salt
+                if (!string.IsNullOrWhiteSpace(vm.NewPassword))
+                {
+                    // must provide current password to change
+                    if (string.IsNullOrWhiteSpace(vm.CurrentPassword))
+                    {
+                        ModelState.AddModelError("CurrentPassword", "Please enter your current password.");
+                        tx.Rollback();
+                        return View(vm);
+                    }
+
+                    string hashStr, saltStr;
+
+                    // byte[]? storedHash = null, storedSalt = null;
+                    using (var readPwd = new NpgsqlCommand(
+                        "SELECT password_hash, password_salt FROM users WHERE user_id=@id;", conn, tx))
+                    {
+                        readPwd.Parameters.AddWithValue("id", userId);
+                        using var r = readPwd.ExecuteReader();
+                        if (!r.Read())
+                        {
+                            tx.Rollback();
+                            return NotFound();
+                        }
+                        object hObj = r["password_hash"];
+                        object sObj = r["password_salt"];
+
+                        hashStr = hObj is byte[] hb ? Convert.ToBase64String(hb) : (string)hObj;
+                        saltStr = sObj is byte[] sb ? Convert.ToBase64String(sb) : (string)sObj;
+                    }
+
+                    var ok = PasswordHasher.Verify(vm.CurrentPassword!, hashStr, saltStr);
+                    if (!ok)
+                    {
+                        ModelState.AddModelError("CurrentPassword", "Current password is incorrect.");
+                        tx.Rollback();
+                        return View(vm);
+                    }
+
+                    var (newHash, newSalt) = PasswordHasher.HashPassword(vm.NewPassword!);
+                    using var updPwd = new NpgsqlCommand(
+                        "UPDATE users SET password_hash=@h, password_salt=@s WHERE user_id=@id;", conn, tx);
+                    updPwd.Parameters.AddWithValue("h", newHash);
+                    updPwd.Parameters.AddWithValue("s", newSalt);
+                    updPwd.Parameters.AddWithValue("id", userId);
+                    updPwd.ExecuteNonQuery();
+                }
+
+                tx.Commit();
+
+                // 3) Refresh the auth cookie so the displayed Name updates immediately
+                await RefreshCookieName(vm.FullName);
+
+                TempData["ProfileMessage"] = "Profile updated successfully.";
+                return RedirectToAction(nameof(Index));
+            }
+            catch
+            {
+                try { tx.Rollback(); } catch { }
+                ModelState.AddModelError(string.Empty, "Could not update profile. Please try again.");
+                return View(vm);
+            }
+        }
+
+        private async Task RefreshCookieName(string fullName)
+        {
+            // rebuild claims, preserving Id + Role + Email, but updating Name
+            var identity = (ClaimsIdentity)User.Identity!;
+            var claims = identity.Claims.ToList();
+
+            // replace or add ClaimTypes.Name
+            claims.RemoveAll(c => c.Type == ClaimTypes.Name);
+            claims.Add(new Claim(ClaimTypes.Name, fullName));
+
+            var newIdentity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme);
+            var principal = new ClaimsPrincipal(newIdentity);
+
+            await HttpContext.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, principal);
+        }
+    }
+}

--- a/Models/ProfileVm.cs
+++ b/Models/ProfileVm.cs
@@ -1,0 +1,29 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace EventTicketingSystem.Models
+{
+    public class ProfileVm
+    {
+        [Display(Name = "Email")]
+        public string Email { get; set; } = "";   // read-only in UI
+
+        [Required, Display(Name = "Full name")]
+        [StringLength(200)]
+        public string FullName { get; set; } = "";
+
+        // Change password (optional)
+        [DataType(DataType.Password)]
+        [Display(Name = "Current password")]
+        public string? CurrentPassword { get; set; }
+
+        [DataType(DataType.Password)]
+        [Display(Name = "New password")]
+        [MinLength(6, ErrorMessage = "New password must be at least 6 characters.")]
+        public string? NewPassword { get; set; }
+
+        [DataType(DataType.Password)]
+        [Display(Name = "Confirm new password")]
+        [Compare(nameof(NewPassword), ErrorMessage = "Passwords do not match.")]
+        public string? ConfirmNewPassword { get; set; }
+    }
+}

--- a/Views/Profile/Index.cshtml
+++ b/Views/Profile/Index.cshtml
@@ -1,0 +1,64 @@
+@model EventTicketingSystem.Models.ProfileVm
+@{
+    ViewData["Title"] = "My Profile";
+}
+<div class="container py-4" style="max-width:720px;">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h1 class="h4 mb-0">My Profile</h1>
+        <a class="btn btn-outline-secondary" asp-controller="Home" asp-action="Index">Home</a>
+    </div>
+
+    @if (TempData["ProfileMessage"] is string msg)
+    {
+        <div class="alert alert-success">@msg</div>
+    }
+
+    <form method="post" novalidate>
+        @Html.AntiForgeryToken()
+        <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
+
+        <div class="mb-3">
+            <label class="form-label">Email</label>
+            <input class="form-control" value="@Model.Email" readonly />
+            <div class="form-text">Email changes are disabled for this demo.</div>
+        </div>
+
+        <div class="mb-3">
+            <label asp-for="FullName" class="form-label"></label>
+            <input asp-for="FullName" class="form-control" />
+            <span asp-validation-for="FullName" class="text-danger"></span>
+        </div>
+
+        <hr class="my-4" />
+
+        <div class="mb-2">
+            <strong>Change Password (optional)</strong>
+        </div>
+        <div class="mb-3">
+            <label asp-for="CurrentPassword" class="form-label"></label>
+            <input asp-for="CurrentPassword" class="form-control" />
+            <span asp-validation-for="CurrentPassword" class="text-danger"></span>
+        </div>
+        <div class="row g-3">
+            <div class="col-md-6">
+                <label asp-for="NewPassword" class="form-label"></label>
+                <input asp-for="NewPassword" class="form-control" />
+                <span asp-validation-for="NewPassword" class="text-danger"></span>
+            </div>
+            <div class="col-md-6">
+                <label asp-for="ConfirmNewPassword" class="form-label"></label>
+                <input asp-for="ConfirmNewPassword" class="form-control" />
+                <span asp-validation-for="ConfirmNewPassword" class="text-danger"></span>
+            </div>
+        </div>
+
+        <div class="mt-4 d-flex gap-2">
+            <a class="btn btn-outline-secondary" asp-controller="Home" asp-action="Index">Cancel</a>
+            <button class="btn btn-dark" type="submit">Save Changes</button>
+        </div>
+    </form>
+</div>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -98,6 +98,7 @@
                         {
                             <!-- Optional: profile dropdown instead of plain text -->
                             <div class="dropdown">
+                                <a class="btn btn-outline-secondary" asp-controller="Profile" asp-action="Index">Profile</a>
                                 <button class="btn btn-outline-dark dropdown-toggle" type="button" id="profileMenu"
                                     data-bs-toggle="dropdown" aria-expanded="false">
                                     @User.Identity!.Name


### PR DESCRIPTION
This pull request introduces a user profile management feature, allowing authenticated users to view and update their profile information (full name and password) through a new controller, view model, and Razor view. The changes cover backend logic for securely updating user data, frontend form design, and navigation updates.

**Profile Management Feature**

* Added `ProfileController` with actions to display and update the user's profile, including secure password change logic and authentication cookie refresh for immediate UI updates.
* Created `ProfileVm` view model to represent profile data and validation rules for editing the user's full name and changing their password.
* Implemented `Views/Profile/Index.cshtml` Razor view for profile editing, including form validation, password change fields, and success/error messaging.

**Navigation Update**

* Added a "Profile" button to the shared layout, allowing users to easily access the new profile page from the site header.